### PR TITLE
Added bet participation feature

### DIFF
--- a/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipation.java
+++ b/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipation.java
@@ -25,4 +25,8 @@ public class BetParticipation extends AuditingEntity<BetParticipation> {
     @JoinColumn(name = "selected_option_id", nullable = false)
     private BetOption selectedOption;
 
+    public BetParticipation withSelectedOption(BetOption selectedOption) {
+        this.selectedOption = selectedOption;
+        return this;
+    }
 }

--- a/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationController.java
+++ b/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationController.java
@@ -1,5 +1,6 @@
 package com.chromeckap.backend.bet.participation;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -10,23 +11,29 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @Slf4j
 public class BetParticipationController {
-
-    @GetMapping("/{betId}/results")
-    public ResponseEntity<BetParticipationResponse> getUsersBetResults(
-            @PathVariable int groupId,
-            @PathVariable int categoryId,
-            @PathVariable int betId
-    ) {
-        return ResponseEntity.ok().build();
-    }
+    private final BetParticipationService betParticipationService;
 
     @PostMapping("/{betId}/participate")
-    public ResponseEntity<Void> participateInBet(
-            @PathVariable long groupId,
-            @PathVariable long categoryId,
+    public ResponseEntity<Long> participateInBet(
+            @PathVariable final Long groupId,
+            @PathVariable final Long categoryId,
+            @PathVariable final Long betId,
+            @RequestBody @Valid final BetParticipationRequest request
+    ) {
+        log.info("User participating in bet with id {} in category {} and group {}", betId, categoryId, groupId);
+        Long response = betParticipationService.participateInBet(groupId, categoryId, betId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{betId}/participation")
+    public ResponseEntity<Void> cancelParticipationInBet(
+            @PathVariable final Long groupId,
+            @PathVariable final Long categoryId,
             @PathVariable final Long betId
     ) {
-        return ResponseEntity.ok().build();
+        log.info("User requests cancellation of participation in bet {} for category {} and group {}", betId, categoryId, groupId);
+        betParticipationService.cancelParticipationInBet(groupId, categoryId, betId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationMapper.java
+++ b/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationMapper.java
@@ -1,0 +1,13 @@
+package com.chromeckap.backend.bet.participation;
+
+import jakarta.validation.Valid;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BetParticipationMapper {
+
+    public BetParticipation toEntity(@Valid final BetParticipationRequest request) {
+        return BetParticipation.builder()
+                .build();
+    }
+}

--- a/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationRepository.java
+++ b/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationRepository.java
@@ -3,6 +3,9 @@ package com.chromeckap.backend.bet.participation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 interface BetParticipationRepository extends JpaRepository<BetParticipation, Long> {
+    Optional<BetParticipation> findBySelectedOption_Bet_IdAndCreatedBy(Long betId, String createdBy);
 }

--- a/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationRequest.java
+++ b/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationRequest.java
@@ -1,0 +1,6 @@
+package com.chromeckap.backend.bet.participation;
+
+public record BetParticipationRequest(
+        Long optionId
+) {
+}

--- a/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationService.java
+++ b/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationService.java
@@ -1,0 +1,99 @@
+package com.chromeckap.backend.bet.participation;
+
+import com.chromeckap.backend.bet.Bet;
+import com.chromeckap.backend.bet.BetService;
+import com.chromeckap.backend.bet.option.BetOption;
+import com.chromeckap.backend.bet.option.BetOptionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BetParticipationService {
+    private final BetParticipationRepository betParticipationRepository;
+    private final BetParticipationMapper betParticipationMapper;
+    private final BetParticipationValidator betParticipationValidator;
+    private final BetOptionService betOptionService;
+    private final BetService betService;
+
+    /**
+     * Allows a user to participate in a bet by selecting a specific option.
+     * <p>
+     * The method performs the following steps:
+     * <ul>
+     *     <li>Ensures that the user is a member of the given group.</li>
+     *     <li>Fetches the selected bet option by its id.</li>
+     *     <li>Validates that the option belongs to the given bet.</li>
+     *     <li>Creates a new {@link BetParticipation} entity linked to the user and the option.</li>
+     *     <li>Persists the participation in the repository.</li>
+     * </ul>
+     *
+     * @param groupId   the id of the group where the bet resides
+     * @param categoryId the id of the category to which the bet belongs to
+     * @param betId     the id of the bet to participate in
+     * @param request   the participation request containing the selected option id
+     * @return the id of the newly created bet participation
+     * @throws IllegalArgumentException if the selected option does not belong to the given bet
+     */
+    @Transactional
+    @PreAuthorize("@groupMembershipValidator.isGroupMember(#groupId)")
+    public Long participateInBet(final Long groupId, final Long categoryId,final Long betId, @Valid final BetParticipationRequest request) {
+        log.debug("User participating in bet with id {} in category {} and group {}", betId, categoryId, groupId);
+
+        Bet bet = betService.findBetByIdAndCategoryId(betId, categoryId);
+        betParticipationValidator.validateBetOpen(bet);
+
+        BetOption selectedOption = betOptionService.findBetOptionById(request.optionId());
+        betParticipationValidator.validateOptionBelongsToBet(selectedOption, bet);
+
+        BetParticipation betParticipation = betParticipationMapper.toEntity(request)
+                .withSelectedOption(selectedOption)
+                .withCreatedBy(SecurityContextHolder.getContext().getAuthentication().getName());
+
+        BetParticipation savedBetParticipation = betParticipationRepository.save(betParticipation);
+        log.info("Successfully created bet participation {}", savedBetParticipation);
+
+        return  savedBetParticipation.getId();
+    }
+
+    /**
+     * Allows a user to cancel their participation in a bet.
+     * <p>
+     * The method performs the following steps:
+     * <ul>
+     *     <li>Ensures that the user is a member of the given group.</li>
+     *     <li>Fetches the bet by its id and category id.</li>
+     *     <li>Validates that the bet is still open and not resolved.</li>
+     *     <li>Finds the user's existing participation in the bet.</li>
+     *     <li>Deletes the participation from the repository.</li>
+     * </ul>
+     *
+     * @param groupId    the id of the group where the bet resides
+     * @param categoryId the id of the category to which the bet belongs
+     * @param betId      the id of the bet from which the user wants to cancel participation
+     * @throws IllegalArgumentException if the user has no participation in the bet
+     */
+    @Transactional
+    @PreAuthorize("@groupMembershipValidator.isGroupMember(#groupId)")
+    public void cancelParticipationInBet(final Long groupId, final Long categoryId, final Long betId) {
+        String currentUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+        log.debug("User={} requests cancellation of participation in bet={} in group {}", currentUserId, betId, groupId);
+
+        Bet bet = betService.findBetByIdAndCategoryId(betId, categoryId);
+        betParticipationValidator.validateBetOpen(bet);
+
+        BetParticipation participation = betParticipationRepository.findBySelectedOption_Bet_IdAndCreatedBy(betId, currentUserId)
+                .orElseThrow(() -> new IllegalArgumentException("No participation found for user " + currentUserId + " in bet " + betId));
+
+        betParticipationRepository.delete(participation);
+
+        log.info("User={} successfully canceled participation in bet={}", currentUserId, betId);
+    }
+
+}

--- a/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationValidator.java
+++ b/backend/src/main/java/com/chromeckap/backend/bet/participation/BetParticipationValidator.java
@@ -1,0 +1,27 @@
+package com.chromeckap.backend.bet.participation;
+
+import com.chromeckap.backend.bet.Bet;
+import com.chromeckap.backend.bet.BetStatus;
+import com.chromeckap.backend.bet.option.BetOption;
+import com.chromeckap.backend.exception.BetClosedException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BetParticipationValidator {
+
+    public void validateBetOpen(Bet bet) {
+        if (bet.isResolved() || bet.getStatus() != BetStatus.OPEN) {
+            throw new BetClosedException("Bet with id " + bet.getId() + " is not open for participation.");
+        }
+    }
+
+    public void validateOptionBelongsToBet(BetOption option, Bet bet) {
+        if (!option.getBet().getId().equals(bet.getId())) {
+            throw new IllegalArgumentException(
+                    "Option with id %s does not belong to bet %s"
+                            .formatted(option.getId(), bet.getId())
+            );
+        }
+    }
+
+}

--- a/backend/src/main/java/com/chromeckap/backend/exception/BetClosedException.java
+++ b/backend/src/main/java/com/chromeckap/backend/exception/BetClosedException.java
@@ -1,0 +1,7 @@
+package com.chromeckap.backend.exception;
+
+public class BetClosedException extends RuntimeException {
+    public BetClosedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
- Implemented BetParticipationService with methods to participate and cancel participation
- Added BetParticipationValidator for validating bet status and option-bet relation
- Created BetParticipationRequest record for API input
- Added BetParticipationMapper to map request to entity
- Extended BetParticipationController with POST /participate and DELETE /participation endpoints
- Removed GET /results from BetParticipationController as it is not currently used